### PR TITLE
Fix the event name in speakers page title

### DIFF
--- a/src/pages/speakers-page.html
+++ b/src/pages/speakers-page.html
@@ -149,7 +149,7 @@
     </style>
 
     <polymer-helmet
-      title="Speakers | GDG DevFest Ukraine"
+      title="Speakers | GDG DevFest London"
       description="Learn more about speakers"
       active="[[_setHelmetData(active, isDialogOpened)]]"
     ></polymer-helmet>


### PR DESCRIPTION
Fix the event name in speakers page title by replacing Ukraine with London